### PR TITLE
Generalising run_forecast_plots

### DIFF
--- a/run_forecast_plots.sh
+++ b/run_forecast_plots.sh
@@ -131,7 +131,7 @@ if [[ "${ROLLING}" == true ]]; then
             LOGFILE="${RMSE_LOG}"
         fi
         OUTPUT="${OUTPUT_DIR}/${element}.mp4"
-        ffmpeg -framerate 10 -y -pattern_type glob -i "${OUTPUT_DIR}/${element}*.png" \
+        ffmpeg -framerate 10 -y -pattern_type glob -i "${OUTPUT_DIR}/${element}.*.png" \
             -vcodec libx264 -pix_fmt yuv420p $OUTPUT >> $LOGFILE
     done
 fi

--- a/run_forecast_plots.sh
+++ b/run_forecast_plots.sh
@@ -114,7 +114,9 @@ if [[ "${LEADTIME_AVG}" == true ]]; then
     do
         if [ "${element}" == "sic" ] ; then
             continue
-        elif [ "${element}" == "binacc" ] ; then
+        fi
+        OUTPUT="${OUTPUT_DIR}/${element}_leadtime_avg.png"
+        if [ "${element}" == "binacc" ] ; then
             echo "Producing leadtime averaged binary accuracy plot (${OUTPUT})"
             LOGFILE="${BINACC_LOG}"
         elif [ "${element}" == "sie" ] ; then
@@ -130,7 +132,6 @@ if [[ "${LEADTIME_AVG}" == true ]]; then
             echo "Producing leadtime averaged RMSE plot (${OUTPUT})"
             LOGFILE="${RMSE_LOG}"
         fi
-        OUTPUT="${OUTPUT_DIR}/${element}_leadtime_avg.png"
         icenet_plot_leadtime_avg $HEMI $FORECAST_FILE \
             -m $element -ao "all" -s -sm 1 $E_FLAG \
             -o $OUTPUT >> $LOGFILE
@@ -143,7 +144,9 @@ if [[ "${ROLLING}" == true ]]; then
     do
         if [ "${element}" == "sic" ] ; then
             continue
-        elif [ "${element}" == "binacc" ] ; then
+        fi
+        OUTPUT="${OUTPUT_DIR}/${element}.mp4"
+        if [ "${element}" == "binacc" ] ; then
             echo "Producing rolling binary accuracy plot (${OUTPUT})"
             LOGFILE="${BINACC_LOG}"
         elif [ "${element}" == "sie" ] ; then
@@ -159,8 +162,7 @@ if [[ "${ROLLING}" == true ]]; then
             echo "Producing rolling RMSE plot (${OUTPUT})"
             LOGFILE="${RMSE_LOG}"
         fi
-        OUTPUT="${OUTPUT_DIR}/${element}.mp4"
-        # determine whether or not to stitch together the leadtime averaged plot
+        # determine whether or not to stitch the leadtime averaged plot
         if [[ "${LEADTIME_AVG}" == true ]]; then
             INPUTS="${OUTPUT_DIR}/${element}*.png"
         else

--- a/run_forecast_plots.sh
+++ b/run_forecast_plots.sh
@@ -102,7 +102,7 @@ cat ${FORECAST_NAME}.csv | while read -r FORECAST_DATE; do
         elif [ "${element}" == "sic" ] ; then
             OUTPUT="${OUTPUT_DIR}/${element}.${FORECAST_DATE}.mp4"
             echo "Producing SIC error video for $FORECAST_DATE (${OUTPUT})"
-            icenet_plot_sic_error -v -o OUTPUT \
+            icenet_plot_sic_error -v -o $OUTPUT \
                 $HEMI $FORECAST_FILE $FORECAST_DATE >> $SICERR_LOG 2>&1
         fi
     done
@@ -112,8 +112,9 @@ done
 if [[ "${ROLLING}" == true ]]; then
     for element in "${METRICS[@]}"
     do
-        OUTPUT="${OUTPUT_DIR}/${element}.mp4"
-        if [ "${element}" == "binacc" ] ; then
+        if [ "${element}" == "sic" ] ; then
+            continue
+        elif [ "${element}" == "binacc" ] ; then
             echo "Producing rolling binary accuracy plot (${OUTPUT})"
             LOGFILE="${BINACC_LOG}"
         elif [ "${element}" == "sie" ] ; then
@@ -129,6 +130,7 @@ if [[ "${ROLLING}" == true ]]; then
             echo "Producing rolling RMSE plot (${OUTPUT})"
             LOGFILE="${RMSE_LOG}"
         fi
+        OUTPUT="${OUTPUT_DIR}/${element}.mp4"
         ffmpeg -framerate 10 -y -pattern_type glob -i "${OUTPUT_DIR}/${element}*.png" \
             -vcodec libx264 -pix_fmt yuv420p $OUTPUT >> $LOGFILE
     done
@@ -138,8 +140,9 @@ fi
 if [[ "${LEADTIME_AVG}" == true ]]; then
     for element in "${METRICS[@]}"
     do
-        OUTPUT="${OUTPUT_DIR}/${element}_leadtime_avg.png"
-        if [ "${element}" == "binacc" ] ; then
+        if [ "${element}" == "sic" ] ; then
+            continue
+        elif [ "${element}" == "binacc" ] ; then
             echo "Producing leadtime averaged binary accuracy plot (${OUTPUT})"
             LOGFILE="${BINACC_LOG}"
         elif [ "${element}" == "sie" ] ; then
@@ -155,6 +158,7 @@ if [[ "${LEADTIME_AVG}" == true ]]; then
             echo "Producing leadtime averaged RMSE plot (${OUTPUT})"
             LOGFILE="${RMSE_LOG}"
         fi
+        OUTPUT="${OUTPUT_DIR}/${element}_leadtime_avg.png"
         icenet_plot_leadtime_avg $HEMI $FORECAST_FILE \
             -m $element -ao "all" -s -sm 1 $E_FLAG \
             -o $OUTPUT >> $LOGFILE

--- a/run_forecast_plots.sh
+++ b/run_forecast_plots.sh
@@ -2,9 +2,55 @@
 
 source ENVS
 
-if [ $# -lt 2 ] || [ "$1" == "-h" ]; then
-    echo "Usage $0 <forecast_name> <hemisphere>"
+if [ $# -lt 2 ] || [ "$1" == "-h" ] ; then
+    echo "Usage $0 [-m <metrics>] [-e] [-r] [-l] <forecast_name> <hemisphere>"
 fi
+
+# default values for metrics to produce and to compare with ECMWF
+METRICS="binacc,sic-video"
+ECMWF="false"
+ROLLING="false"
+LEADTIME_AVG="false"
+OPTIND=1
+while getopts "m:erl" opt; do
+    case "$opt" in
+        m)  METRICS=${OPTARG} ;;
+        e)  ECMWF="true" ;;
+        r)  ROLLING="true" ;;
+        l)  LEADTIME_AVG="true"
+    esac
+done
+
+# split on commas
+METRICS=(${METRICS//,/ })
+
+# check if metric is valid
+VALID_METRICS=("binacc" "sie" "mae" "mse" "rmse" "sic-video")
+for element in "${METRICS[@]}"
+do
+    if [[ ! "${VALID_METRICS[*]}" =~ "${element}" ]] ; then
+        # element is not in VALID_METRICS 
+        echo "'${element}' is not a valid metric"
+        exit 1
+    fi
+done
+
+# determine whether or not to compare with ECMWF
+if [[ "${ECMWF}" == true ]]; then
+    echo "Generating (${METRICS[@]}) plots for forecast (with comparison with ECMWF)"
+    E_FLAG="-e"
+else
+    echo "Generating (${METRICS[@]}) plots for forecast (without comparison with ECMWF)"
+    E_FLAG=""
+fi
+
+if [[ "${LEADTIME_AVG}" == true ]]; then
+    echo "Also generating leadtime averaged plots for the above metrics"
+fi
+
+shift $((OPTIND-1))
+
+echo "Leftovers from getopt: $@"
 
 FORECAST="$1"
 HEMI="$2"
@@ -12,25 +58,105 @@ HEMI="$2"
 FORECAST_NAME=${FORECAST}_${HEMI}
 FORECAST_FILE="results/predict/${FORECAST_NAME}.nc"
 LOG_PREFIX="logs/${FORECAST_NAME}"
-BINACC_LOG="${LOG_PREFIX}_bin_accuracy.log"
+BINACC_LOG="${LOG_PREFIX}_binacc.log"
+SIE_LOG="${LOG_PREFIX}_sie.log"
+MAE_LOG="${LOG_PREFIX}_mae.log"
+MSE_LOG="${LOG_PREFIX}_mse.log"
+RMSE_LOG="${LOG_PREFIX}_rmse.log"
 SICERR_LOG="${LOG_PREFIX}_sic_error.log"
 OUTPUT_DIR="plot/$FORECAST_NAME"
 
-if [ -d $OUTPUT_DIR ]; then
-    rm -v $BINACC_LOG $SICERR_LOG
+if [ -d $OUTPUT_DIR ] ; then
+    # remove existing log files if they exist
+    rm -v -f $BINACC_LOG $SIE_LOG $MAE_LOG $MSE_LOG $RMSE_LOG $SICERR_LOG
 fi
 mkdir -p $OUTPUT_DIR
 
 echo "Reading ${FORECAST_NAME}.csv"
 
+# create metric plots for each forecast date
 cat ${FORECAST_NAME}.csv | while read -r FORECAST_DATE; do
-    echo "Producing binary accuracy for $FORECAST_DATE";
-    icenet_plot_bin_accuracy -b -e -v \
-        -o ${OUTPUT_DIR}/bin_accuracy.${FORECAST_DATE}.png \
-        $HEMI $FORECAST_FILE $FORECAST_DATE >>$BINACC_LOG 2>&1
-
-    echo "Producing SIC error for $FORECAST_DATE";
-    icenet_plot_sic_error -v \
-        -o ${OUTPUT_DIR}/sic_error.${FORECAST_DATE}.mp4 \
-        $HEMI $FORECAST_FILE $FORECAST_DATE >>$SICERR_LOG 2>&1
+    for element in "${METRICS[@]}"
+    do
+        OUTPUT="${OUTPUT_DIR}/${element}.${FORECAST_DATE}.png"
+        if [ "${element}" == "binacc" ] ; then
+            echo "Producing binary accuracy plot for $FORECAST_DATE (${OUTPUT})"
+            icenet_plot_bin_accuracy -b $E_FLAG -v -o $OUTPUT \
+                $HEMI $FORECAST_FILE $FORECAST_DATE >> $BINACC_LOG 2>&1
+        elif [ "${element}" == "sie" ] ; then
+            echo "Producing sea ice extent error plot for $FORECAST_DATE (${OUTPUT})"
+            icenet_plot_sie_error -b $E_FLAG -v -o $OUTPUT \
+                $HEMI $FORECAST_FILE $FORECAST_DATE >> $SIE_LOG 2>&1
+        elif [ "${element}" == "mae" ] ; then
+            echo "Producing MAE plot for $FORECAST_DATE (${OUTPUT})"
+            icenet_plot_metrics -b $E_FLAG -v -m "MAE" -o $OUTPUT \
+                $HEMI $FORECAST_FILE $FORECAST_DATE >> $MAE_LOG 2>&1
+        elif [ "${element}" == "mse" ] ; then
+            echo "Producing MSE plot for $FORECAST_DATE (${OUTPUT})"
+            icenet_plot_metrics -b $E_FLAG -v -m "MSE" -o $OUTPUT \
+                $HEMI $FORECAST_FILE $FORECAST_DATE >> $MSE_LOG 2>&1
+        elif [ "${element}" == "rmse" ] ; then
+            echo "Producing RMSE plot for $FORECAST_DATE (${OUTPUT})"
+            icenet_plot_metrics -b $E_FLAG -v -m "RMSE" -o $OUTPUT \
+                $HEMI $FORECAST_FILE $FORECAST_DATE >> $RMSE_LOG 2>&1
+        elif [ "${element}" == "sic-video" ] ; then
+            OUTPUT="${OUTPUT_DIR}/${element}.${FORECAST_DATE}.mp4"
+            echo "Producing SIC error video for $FORECAST_DATE (${OUTPUT})"
+            icenet_plot_sic_error -v -o OUTPUT \
+                $HEMI $FORECAST_FILE $FORECAST_DATE >> $SICERR_LOG 2>&1
+        fi
+    done
 done
+
+# stitch together metric plots if requested
+if [[ "${ROLLING}" == true ]]; then
+    for element in "${METRICS[@]}"
+    do
+        OUTPUT="${OUTPUT_DIR}/${element}.mp4"
+        if [ "${element}" == "binacc" ] ; then
+            echo "Producing rolling binary accuracy plot (${OUTPUT})"
+            LOGFILE="${BINACC_LOG}"
+        elif [ "${element}" == "sie" ] ; then
+            echo "Producing rolling sea ice extent error plot (${OUTPUT})"
+            LOGFILE="${SIE_LOG}"
+        elif [ "${element}" == "mae" ] ; then
+            echo "Producing rolling MAE plot (${OUTPUT})"
+            LOGFILE="${MAE_LOG}"
+        elif [ "${element}" == "mse" ] ; then
+            echo "Producing rolling MSE plot (${OUTPUT})"
+            LOGFILE="${MSE_LOG}"
+        elif [ "${element}" == "rmse" ] ; then
+            echo "Producing rolling RMSE plot (${OUTPUT})"
+            LOGFILE="${RMSE_LOG}"
+        fi
+        ffmpeg -framerate 10 -y -pattern_type glob -i "${OUTPUT_DIR}/${element}*.png" \
+            -vcodec libx264 -pix_fmt yuv420p $OUTPUT >> $LOGFILE
+    done
+fi
+
+# produce leadtime averaged plots
+if [[ "${LEADTIME_AVG}" == true ]]; then
+    for element in "${METRICS[@]}"
+    do
+        OUTPUT="${OUTPUT_DIR}/${element}_leadtime_avg.png"
+        if [ "${element}" == "binacc" ] ; then
+            echo "Producing leadtime averaged binary accuracy plot (${OUTPUT})"
+            LOGFILE="${BINACC_LOG}"
+        elif [ "${element}" == "sie" ] ; then
+            echo "Producing leadtime averaged sea ice extent error plot (${OUTPUT})"
+            LOGFILE="${SIE_LOG}"
+        elif [ "${element}" == "mae" ] ; then
+            echo "Producing leadtime averaged MAE plot (${OUTPUT})"
+            LOGFILE="${MAE_LOG}"
+        elif [ "${element}" == "mse" ] ; then
+            echo "Producing leadtime averaged MSE plot (${OUTPUT})"
+            LOGFILE="${MSE_LOG}"
+        elif [ "${element}" == "rmse" ] ; then
+            echo "Producing leadtime averaged RMSE plot (${OUTPUT})"
+            LOGFILE="${RMSE_LOG}"
+        fi
+        icenet_plot_leadtime_avg $HEMI $FORECAST_FILE \
+            -m $element -ao "all" -s -sm 1 $E_FLAG \
+            -o $OUTPUT >> $LOGFILE
+    done
+fi

--- a/run_forecast_plots.sh
+++ b/run_forecast_plots.sh
@@ -160,7 +160,13 @@ if [[ "${ROLLING}" == true ]]; then
             LOGFILE="${RMSE_LOG}"
         fi
         OUTPUT="${OUTPUT_DIR}/${element}.mp4"
-        ffmpeg -framerate 10 -y -pattern_type glob -i "${OUTPUT_DIR}/${element}.*.png" \
+        # determine whether or not to stitch together the leadtime averaged plot
+        if [[ "${LEADTIME_AVG}" == true ]]; then
+            INPUTS="${OUTPUT_DIR}/${element}*.png"
+        else
+            INPUTS="${OUTPUT_DIR}/${element}.*.png"
+        fi
+        ffmpeg -framerate 10 -y -pattern_type glob -i INPUTS \
             -vcodec libx264 -pix_fmt yuv420p $OUTPUT >> $LOGFILE
     done
 fi

--- a/run_forecast_plots.sh
+++ b/run_forecast_plots.sh
@@ -7,7 +7,7 @@ if [ $# -lt 2 ] || [ "$1" == "-h" ] ; then
 fi
 
 # default values for metrics to produce and to compare with ECMWF
-METRICS="binacc,sic-video"
+METRICS="binacc,sic"
 ECMWF="false"
 ROLLING="false"
 LEADTIME_AVG="false"
@@ -25,7 +25,7 @@ done
 METRICS=(${METRICS//,/ })
 
 # check if metric is valid
-VALID_METRICS=("binacc" "sie" "mae" "mse" "rmse" "sic-video")
+VALID_METRICS=("binacc" "sie" "mae" "mse" "rmse" "sic")
 for element in "${METRICS[@]}"
 do
     if [[ ! "${VALID_METRICS[*]}" =~ "${element}" ]] ; then
@@ -63,7 +63,7 @@ SIE_LOG="${LOG_PREFIX}_sie.log"
 MAE_LOG="${LOG_PREFIX}_mae.log"
 MSE_LOG="${LOG_PREFIX}_mse.log"
 RMSE_LOG="${LOG_PREFIX}_rmse.log"
-SICERR_LOG="${LOG_PREFIX}_sic_error.log"
+SICERR_LOG="${LOG_PREFIX}_sic.log"
 OUTPUT_DIR="plot/$FORECAST_NAME"
 
 if [ -d $OUTPUT_DIR ] ; then
@@ -99,7 +99,7 @@ cat ${FORECAST_NAME}.csv | while read -r FORECAST_DATE; do
             echo "Producing RMSE plot for $FORECAST_DATE (${OUTPUT})"
             icenet_plot_metrics -b $E_FLAG -v -m "RMSE" -o $OUTPUT \
                 $HEMI $FORECAST_FILE $FORECAST_DATE >> $RMSE_LOG 2>&1
-        elif [ "${element}" == "sic-video" ] ; then
+        elif [ "${element}" == "sic" ] ; then
             OUTPUT="${OUTPUT_DIR}/${element}.${FORECAST_DATE}.mp4"
             echo "Producing SIC error video for $FORECAST_DATE (${OUTPUT})"
             icenet_plot_sic_error -v -o OUTPUT \

--- a/run_prediction.sh
+++ b/run_prediction.sh
@@ -7,7 +7,7 @@ set -e -o pipefail
 conda activate $ICENET_CONDA
 
 if [ $# -lt 3 ] || [ "$1" == "-h" ]; then
-  echo "$0 [-m <metrics>] [-e] <forecast name> <model> <hemisphere> [date_vars] [train_data_name]"
+  echo "$0 [-m <metrics>] [-e] [-r] [-l] <forecast name> <model> <hemisphere> [date_vars] [train_data_name]"
   exit 1
 fi
 

--- a/run_prediction.sh
+++ b/run_prediction.sh
@@ -85,4 +85,4 @@ icenet_dataset_create -l $LAG -c ${FORECAST}_${HEMI} $HEMI
 ./run_predict_ensemble.sh -i $DATASET -f $FILTER_FACTOR -p $PREP_SCRIPT \
     $MODEL ${FORECAST}_${HEMI} ${FORECAST}_${HEMI} ${FORECAST}_${HEMI}.csv
 
-./run_forecast_plots.sh ${METRICS_FLAG} ${E_FLAG} ${R_FLAG} ${L_FLAG} $FORECAST $HEMI
+./run_forecast_plots.sh $METRICS_FLAG $E_FLAG $R_FLAG $L_FLAG $FORECAST $HEMI

--- a/run_prediction.sh
+++ b/run_prediction.sh
@@ -7,9 +7,30 @@ set -e -o pipefail
 conda activate $ICENET_CONDA
 
 if [ $# -lt 3 ] || [ "$1" == "-h" ]; then
-  echo "$0 <forecast name> <model> <hemisphere> [date_vars] [train_data_name]"
+  echo "$0 [-m <metrics>] [-e] <forecast name> <model> <hemisphere> [date_vars] [train_data_name]"
   exit 1
 fi
+
+# obtaining any arguments that should be passed onto run_forecast_plots.sh
+METRICS_FLAG=""
+E_FLAG=""
+R_FLAG=""
+L_FLAG=""
+OPTIND=1
+while getopts "m:erl" opt; do
+  case "$opt" in
+    m)  METRICS_FLAG="-m ${OPTARG}" ;;
+    e)  E_FLAG="-e" ;;
+    r)  R_FLAG="-r" ;;
+    l)  L_FLAG="-l"
+  esac
+done
+
+echo "Passing on the following argument to run_forecast_plots.sh: ${METRICS_FLAG} ${E_FLAG}"
+
+shift $((OPTIND-1))
+
+echo "Leftovers from getopt: $@"
 
 FORECAST="$1"
 MODEL="$2"
@@ -64,4 +85,4 @@ icenet_dataset_create -l $LAG -c ${FORECAST}_${HEMI} $HEMI
 ./run_predict_ensemble.sh -i $DATASET -f $FILTER_FACTOR -p $PREP_SCRIPT \
     $MODEL ${FORECAST}_${HEMI} ${FORECAST}_${HEMI} ${FORECAST}_${HEMI}.csv
 
-./run_forecast_plots.sh $FORECAST $HEMI
+./run_forecast_plots.sh ${METRICS_FLAG} ${E_FLAG} ${R_FLAG} ${L_FLAG} $FORECAST $HEMI

--- a/run_prediction.sh
+++ b/run_prediction.sh
@@ -7,22 +7,22 @@ set -e -o pipefail
 conda activate $ICENET_CONDA
 
 if [ $# -lt 3 ] || [ "$1" == "-h" ]; then
-  echo "$0 [-m <metrics>] [-e] [-r] [-l] <forecast name> <model> <hemisphere> [date_vars] [train_data_name]"
+  echo "$0 [-m <metrics>] [-e] [-l] [-r] <forecast name> <model> <hemisphere> [date_vars] [train_data_name]"
   exit 1
 fi
 
 # obtaining any arguments that should be passed onto run_forecast_plots.sh
 METRICS_FLAG=""
 E_FLAG=""
-R_FLAG=""
 L_FLAG=""
+R_FLAG=""
 OPTIND=1
 while getopts "m:erl" opt; do
   case "$opt" in
     m)  METRICS_FLAG="-m ${OPTARG}" ;;
     e)  E_FLAG="-e" ;;
-    r)  R_FLAG="-r" ;;
-    l)  L_FLAG="-l"
+    l)  L_FLAG="-l" ;;
+    r)  R_FLAG="-r"
   esac
 done
 
@@ -85,4 +85,4 @@ icenet_dataset_create -l $LAG -c ${FORECAST}_${HEMI} $HEMI
 ./run_predict_ensemble.sh -i $DATASET -f $FILTER_FACTOR -p $PREP_SCRIPT \
     $MODEL ${FORECAST}_${HEMI} ${FORECAST}_${HEMI} ${FORECAST}_${HEMI}.csv
 
-./run_forecast_plots.sh $METRICS_FLAG $E_FLAG $R_FLAG $L_FLAG $FORECAST $HEMI
+./run_forecast_plots.sh $METRICS_FLAG $E_FLAG $L_FLAG $R_FLAG $FORECAST $HEMI


### PR DESCRIPTION
Adding more functionality to `run_forecast_plots.sh` to have options to:
- pass in what metrics to generate (via `-m`)
- to compare with ECMWF (via `-e`)
- to stitch metric plots to create rolling leadtime video (https://github.com/icenet-ai/icenet/issues/145) (via `-r`)
- to produce leadtime averaged (currently just averaging over all forecasts) (via `-l`)

Have also added these options to `run_prediction.sh` to be passed into `run_forecast_plots.sh`.