### PR TITLE
Fixes #42 windows playable videos

### DIFF
--- a/produce_op_assets.sh
+++ b/produce_op_assets.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 display_help() {
-  echo "Usage: $0 <forecast [options] name w/hemi> [region]"
+  echo "Usage: $0 [options] <forecast name w/hemi> [region]"
   echo
   echo "Generate forecast outputs from netCDF prediction file (Outputs: geotiff, png, mp4)"
+  echo "Outputs to 'results/forecast/<forecast name w/hemi>'"
   echo
   echo "Positional arguments:"
   echo "  name			Name of the prediction netCDF file, with hemisphere postfix ('_south'), e.g. 'forecastfile_south'."
@@ -33,7 +34,8 @@ display_help() {
 
 }
 
-# Debugging mode
+start=$(date +%s)
+
 set -e -o pipefail
 
 if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
@@ -85,6 +87,7 @@ if [ -n "$REGION" ]; then
     if [[ "$REGION" == l* ]]; then
         REGION="-z=${REGION:1}"
         printf '\033[0;31mNote: The metrics such as binary accuracy, sic and sie error do not currently support lat/lon based region bounds!\033[0m'
+        echo
     else
         REGION="-r $REGION"
     fi
@@ -196,3 +199,6 @@ for DATE_FORECAST in $( cat ${FORECAST_NAME}.csv ); do
 done
 
 echo "Done, enjoy your forecasts in $OUTPUT_DIR"
+
+end=$(date +%s)
+echo "Elapsed Time: $(($end-$start)) seconds"

--- a/produce_op_assets.sh
+++ b/produce_op_assets.sh
@@ -146,7 +146,7 @@ for DATE_FORECAST in $( cat ${FORECAST_NAME}.csv ); do
 
   echo "Producing stills for manual composition (with coastlines)"
   icenet_plot_forecast $REGION $SCRIPT_ARGS -o $DATE_DIR -l 1..93 $HEMI $FORECAST_FILE $DATE_FORECAST
-  ffmpeg -framerate 5 -pattern_type glob -i ${DATE_DIR}'/'${FORECAST_NAME}'.*.png' -c:v libx264 ${DATE_DIR}/${FORECAST_NAME}.mp4
+  ffmpeg -framerate 5 -pattern_type glob -i ${DATE_DIR}'/'${FORECAST_NAME}'.*.png' -c:v libx264 -pix_fmt yuv420p ${DATE_DIR}/${FORECAST_NAME}.mp4
   rename_gfx $DATE_DIR "${FORECAST_NAME}.${DATE_FORECAST}." '*.png'
 
   echo "Producing movie and stills of ensemble standard deviation in predictions"
@@ -154,7 +154,7 @@ for DATE_FORECAST in $( cat ${FORECAST_NAME}.csv ); do
   rename_gfx $DATE_DIR "${FORECAST_NAME}.${DATE_FORECAST}." '*.stddev.mp4'
 
   icenet_plot_forecast $REGION $SCRIPT_ARGS -s -o $DATE_DIR -l 1..93 $HEMI $FORECAST_FILE $DATE_FORECAST
-  ffmpeg -framerate 5 -pattern_type glob -i ${DATE_DIR}'/'${FORECAST_NAME}'.*.stddev.png' -c:v libx264 ${DATE_DIR}/${FORECAST_NAME}.stddev.mp4
+  ffmpeg -framerate 5 -pattern_type glob -i ${DATE_DIR}'/'${FORECAST_NAME}'.*.stddev.png' -c:v libx264 -pix_fmt yuv420p ${DATE_DIR}/${FORECAST_NAME}.stddev.mp4
   rename_gfx $DATE_DIR "${FORECAST_NAME}.${DATE_FORECAST}." '*.stddev.png'
 
   produce_docs $DATE_DIR


### PR DESCRIPTION
Fixes #42 

Enables `-pix_fmt yuv420p` flag for ffmpeg video output in `produce_op_assets.sh`